### PR TITLE
Add raid_pokemon_form to Webhook

### DIFF
--- a/Sources/RealDeviceMap/Modell/Gym.swift
+++ b/Sources/RealDeviceMap/Modell/Gym.swift
@@ -88,6 +88,7 @@ class Gym: JSONConvertibleObject, WebHookEvent {
                 "level": raidLevel ?? 0,
                 "pokemon_id": raidPokemonId ?? 0,
                 "cp": raidPokemonCp ?? 0,
+                "form": raidPokemonForm,
                 "move_1": raidPokemonMove1 ?? 0,
                 "move_2": raidPokemonMove2 ?? 0,
                 "sponsor_id": exRaidEligible ?? 0,

--- a/Sources/RealDeviceMap/Modell/Gym.swift
+++ b/Sources/RealDeviceMap/Modell/Gym.swift
@@ -88,7 +88,7 @@ class Gym: JSONConvertibleObject, WebHookEvent {
                 "level": raidLevel ?? 0,
                 "pokemon_id": raidPokemonId ?? 0,
                 "cp": raidPokemonCp ?? 0,
-                "form": raidPokemonForm,
+                "form": raidPokemonForm ?? 0,
                 "move_1": raidPokemonMove1 ?? 0,
                 "move_2": raidPokemonMove2 ?? 0,
                 "sponsor_id": exRaidEligible ?? 0,


### PR DESCRIPTION
Missing raid_pokemon_form to Webhook added to reflect better accuracy
for WH users for their alerts